### PR TITLE
update psycopg2 to psycopg2-binary (fixes warning)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ except ImportError:
 
 REQUIREMENTS = [
     'sqlparse >= 0.2.1',
-    'psycopg2 >= 2.6.2',
+    'psycopg2-binary >= 2.7.4',
     'PyYAML >= 3.12'
     ]
 


### PR DESCRIPTION
Fix
```
UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>
```