### PR TITLE
Init schema

### DIFF
--- a/pgmigrate.py
+++ b/pgmigrate.py
@@ -881,6 +881,7 @@ def _main():
     parser.add_argument('-m', '--schema', type=str, help='Operate on schema')
     parser.add_argument('--disable_schema_create',
                         action='store_true',
+                        default=None,
                         help='Do not create schema, when it initialize')
     parser.add_argument('--disable_schema_check',
                         action='store_true',


### PR DESCRIPTION
Здравствуйте,
Возникла проблема. Есть база в которую по разным схемам пишут разные сервисы и внутри этих схем поддерживают свои версии миграций. Доступа на создание чего либо в этой базе (кроме как внутри их схем) у них нету.
При текущей реализации это приводит к ошибке доступа при инициализации миграции так как она в самом начале пробует создать схему внутри базы:
https://github.com/yandex/pgmigrate/blob/master/pgmigrate.py#L389
```
def _init_schema(schema, cursor):
    """
    Create schema_version table
    """
    LOG.info('creating schema')
    cursor.execute(
        SQL('CREATE SCHEMA IF NOT EXISTS {schema}').format(
            schema=Identifier(schema)))
```
Что и вызывает ошибку.

Не могли бы вы исправить это поведение. Как вариант, предлагаю - добавить еще один ключик - disable_schema_create
