### PR TITLE
Upgrade test environment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,19 +12,19 @@ jobs:
     name: Run tests and linters
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 2.7
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 2.7
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.11
       - name: Install tox
         run: |
-          python3.8 -m pip install --upgrade pip
-          python3.8 -m pip install tox
+          python3.11 -m pip install --upgrade pip
+          python3.11 -m pip install tox
       - name: Start PostgreSQL
         run: sudo service postgresql start
       - name: Create PostgreSQL test env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # vim:set ft=dockerfile:
-FROM ubuntu:focal
+FROM ubuntu:jammy
 
 # explicitly set user/group IDs
 RUN groupadd -r postgres --gid=999 && useradd -r -d /var/lib/postgresql -g postgres --uid=999 postgres
 
 # make the "en_US.UTF-8" locale so postgres will be utf-8 enabled by default
-RUN apt-get update && apt-get install -y software-properties-common locales && \
+RUN apt-get update && apt-get install -y ca-certificates locales && \
     rm -rf /var/lib/apt/lists/* && \
     localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
@@ -13,7 +13,8 @@ ENV DEBIAN_FRONTEND noninteractive
 
 ENV PG_MAJOR 15
 
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list
+RUN echo 'deb https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu/ jammy main' > /etc/apt/sources.list.d/deadsnakes-ubuntu-ppa.list
 
 RUN apt-get -o Acquire::AllowInsecureRepositories=true \
         -o Acquire::AllowDowngradeToInsecureRepositories=true update \
@@ -24,12 +25,16 @@ RUN apt-get -o Acquire::AllowInsecureRepositories=true \
         install -y postgresql-common \
         sudo \
         libpq-dev \
-        python3-pip \
         python2.7-dev \
-        python3.8-dev \
+        python3.11-dev \
+        python3.11-lib2to3 \
+        build-essential \
+        curl \
         postgresql-$PG_MAJOR \
         postgresql-contrib-$PG_MAJOR \
-    && pip3 install tox
+    && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+    && python3.11 get-pip.py \
+    && pip3.11 install tox
 
 COPY ./ /dist
 

--- a/pgmigrate.py
+++ b/pgmigrate.py
@@ -97,6 +97,7 @@ class ConflictTerminator(threading.Thread):
     """
     Kills conflicting pids (only on postgresql > 9.6)
     """
+
     def __init__(self, conn_str, interval):
         threading.Thread.__init__(self, name='terminator')
         self.daemon = True

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py38, flake8, pylint, yapf
+envlist = py27, py311, flake8, pylint, yapf
 
 [testenv:py27]
 whitelist_externals = rm
@@ -19,7 +19,7 @@ deps = behave
        coverage
        func_timeout
 
-[testenv:py38]
+[testenv:py311]
 whitelist_externals = rm
 commands = rm -rf htmlcov
            coverage erase
@@ -35,7 +35,7 @@ deps = behave
 commands = flake8 pgmigrate.py setup.py
 deps = flake8
        flake8-string-format
-       flake8-isort>=4.0.0
+       flake8-isort==5.0.0
        flake8-commas
        flake8-quotes
        flake8-copyright
@@ -47,7 +47,7 @@ deps = pylint
 
 [testenv:yapf]
 commands = yapf -pd pgmigrate.py
-deps = yapf==0.29.0
+deps = yapf==0.32.0
 
 [flake8]
 copyright-check = True


### PR DESCRIPTION
1) Upgrade actions to use non-deprecated versions
2) Move to jammy
3) Move to python 3.11
4) Upgrade yapf and apply it to pgmigrate.py
5) Pin flake8-isort version