### PR TITLE
add additional param to conn string to show they can be separated by space

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -45,7 +45,7 @@ callbacks:
 ### Connection
 We could use command-line arguments for connection configuration:
 ```
-admin@localhost foodb $ pgmigrate -c 'dbname=foodb' ...
+admin@localhost foodb $ pgmigrate -c 'dbname=foodb user=foo ...' ...
 ```
 Or configuration file:
 ```


### PR DESCRIPTION
I struggled passing additional connection parameters to the pgmigrate cli. I had to take a look at the code to find out that space character is being used as a delimiter to parse params. I added an additional parameter in the doc so that it is intuitive and easy to understand.