### PR TITLE
Checking migration for non-askii symbols only on demand

### DIFF
--- a/pgmigrate.py
+++ b/pgmigrate.py
@@ -424,7 +424,7 @@ def _get_statements(path):
     """
     with codecs.open(path, encoding='utf-8') as i:
         data = i.read()
-    if u'/* pgmigrate-encoding: utf-8 */' not in data:
+    if u'/* pgmigrate-encoding: ascii */' in data:
         try:
             data.encode('ascii')
         except UnicodeError as exc:


### PR DESCRIPTION
Instead of checking migration for non-askii symbols by default, make this check only on demand